### PR TITLE
Rate Limits for user requests and redirects

### DIFF
--- a/src/Application/Interfaces/IUserDailyRateLimitService.cs
+++ b/src/Application/Interfaces/IUserDailyRateLimitService.cs
@@ -1,0 +1,45 @@
+namespace LinkyFunky.Application.Interfaces;
+
+/// <summary>
+/// Defines which per-user daily quota applies to the current HTTP operation.
+/// </summary>
+public enum UserRateLimitKind
+{
+    /// <summary>
+    /// Creating a new shortcut (POST create shortcut).
+    /// </summary>
+    CreateShortcut,
+
+    /// <summary>
+    /// Following a short link redirect (GET by short code).
+    /// </summary>
+    RedirectShortcut,
+}
+
+/// <summary>
+/// Result of attempting to consume one unit from a user's daily rate limit.
+/// </summary>
+/// <param name="Allowed">Whether the request may proceed.</param>
+/// <param name="Limit">Configured maximum number of operations per UTC day.</param>
+/// <param name="Remaining">Remaining quota after a successful acquire; zero when denied.</param>
+/// <param name="RetryAfter">When denied, time until the next UTC day window resets quota.</param>
+public sealed record RateLimitAcquireResult(
+    bool Allowed,
+    int Limit,
+    int Remaining,
+    TimeSpan? RetryAfter);
+
+/// <summary>
+/// Enforces per-user daily quotas stored in a distributed store (e.g. Redis).
+/// </summary>
+public interface IUserDailyRateLimitService
+{
+    /// <summary>
+    /// Atomically tries to consume one slot for the user in the current UTC calendar day.
+    /// </summary>
+    /// <param name="userId">Authenticated user identifier.</param>
+    /// <param name="kind">Quota bucket to consume.</param>
+    /// <param name="ctk">Cancellation token.</param>
+    /// <returns>Whether the operation is allowed and header-friendly quota metadata.</returns>
+    Task<RateLimitAcquireResult> TryAcquireAsync(Guid userId, UserRateLimitKind kind, CancellationToken ctk);
+}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -2,9 +2,11 @@ using LinkyFunky.Application.Interfaces.Cache;
 using LinkyFunky.Application.Interfaces.Repositories;
 using LinkyFunky.Application.Interfaces;
 using LinkyFunky.Domain.Interfaces;
+using LinkyFunky.Infrastructure.Options;
 using LinkyFunky.Infrastructure.Persistence;
 using LinkyFunky.Infrastructure.Services.Cache;
 using LinkyFunky.Infrastructure.Services.Counters;
+using LinkyFunky.Infrastructure.Services.RateLimiting;
 using LinkyFunky.Infrastructure.Persistence.Repositories;
 using LinkyFunky.Infrastructure.Services.ShortCodeGen;
 using Microsoft.EntityFrameworkCore;
@@ -29,6 +31,7 @@ public static class DependencyInjection
         this IServiceCollection services,
         IConfiguration configuration)
     {
+        services.Configure<RateLimitOptions>(configuration.GetSection(RateLimitOptions.SectionName));
         services.AddServices();
         services.AddDatabase(configuration);
         services.AddRedisDistributedCache(configuration);
@@ -46,6 +49,7 @@ public static class DependencyInjection
         services.AddScoped<IShortcutsRepository, ShortcutsRepository>();
         services.AddScoped<ICacheService, RedisDistributedCache>();
         services.AddScoped<ICounterService, RedisCounterService>();
+        services.AddSingleton<IUserDailyRateLimitService, RedisUserDailyRateLimitService>();
         services.AddSingleton<IShortCodeGen>(_ => new RandomShortCodeGen(DefaultShortCodeLength));
     }
     

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -15,6 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
         <PrivateAssets>all</PrivateAssets>

--- a/src/Infrastructure/Options/RateLimitOptions.cs
+++ b/src/Infrastructure/Options/RateLimitOptions.cs
@@ -1,0 +1,22 @@
+namespace LinkyFunky.Infrastructure.Options;
+
+/// <summary>
+/// Per-user daily rate limit quotas aligned with the product requirements (UTC calendar day).
+/// </summary>
+public sealed class RateLimitOptions
+{
+    /// <summary>
+    /// Configuration section name.
+    /// </summary>
+    public const string SectionName = "RateLimits";
+
+    /// <summary>
+    /// Gets or sets the maximum number of shortcut creations per user per UTC day.
+    /// </summary>
+    public int CreateShortcutPerUtcDay { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets the maximum number of shortcut redirects per user per UTC day.
+    /// </summary>
+    public int RedirectShortcutPerUtcDay { get; set; } = 50;
+}

--- a/src/Infrastructure/Services/RateLimiting/RedisUserDailyRateLimitService.cs
+++ b/src/Infrastructure/Services/RateLimiting/RedisUserDailyRateLimitService.cs
@@ -1,0 +1,103 @@
+using LinkyFunky.Application.Interfaces;
+using LinkyFunky.Infrastructure.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace LinkyFunky.Infrastructure.Services.RateLimiting;
+
+/// <summary>
+/// Redis-backed per-user daily rate limiting using a fixed UTC calendar day window.
+/// </summary>
+/// <param name="connectionMultiplexer">Redis connection multiplexer.</param>
+/// <param name="rateOptions">Configured limits per operation kind.</param>
+/// <param name="configuration">Application configuration for Redis key prefixing.</param>
+public sealed class RedisUserDailyRateLimitService(
+    IConnectionMultiplexer connectionMultiplexer,
+    IOptions<RateLimitOptions> rateOptions,
+    IConfiguration configuration) : IUserDailyRateLimitService
+{
+    const string RedisInstanceNameKey = "Redis:InstanceName";
+    const string RateLimitKeyNamespace = "ratelimit:";
+
+    /// <summary>
+    /// Atomically increments the daily counter and either accepts (within limit) or rolls back when over quota.
+    /// </summary>
+    const string LuaAcquire = """
+        local limit = tonumber(ARGV[1])
+        local ttlSeconds = tonumber(ARGV[2])
+        local current = redis.call('INCR', KEYS[1])
+        if current == 1 then
+          redis.call('EXPIRE', KEYS[1], ttlSeconds)
+        end
+        if current > limit then
+          redis.call('DECR', KEYS[1])
+          return -1
+        end
+        return limit - current
+        """;
+
+    readonly IDatabase _database = connectionMultiplexer.GetDatabase();
+    readonly string _keyPrefix = BuildKeyPrefix(configuration);
+
+    /// <inheritdoc />
+    public async Task<RateLimitAcquireResult> TryAcquireAsync(Guid userId, UserRateLimitKind kind, CancellationToken ctk)
+    {
+        var options = rateOptions.Value;
+        var limit = kind switch
+        {
+            UserRateLimitKind.CreateShortcut => options.CreateShortcutPerUtcDay,
+            UserRateLimitKind.RedirectShortcut => options.RedirectShortcutPerUtcDay,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+        };
+
+        if (limit <= 0)
+            return new(true, limit, int.MaxValue, null);
+
+        var utcNow = DateTime.UtcNow;
+        var ttlSeconds = UtcCalendarDayRateLimit.GetSecondsUntilNextUtcDay(utcNow);
+        var key = BuildRedisKey(kind, userId, utcNow);
+
+        var redisResult = await _database.ScriptEvaluateAsync(
+                LuaAcquire,
+                [key],
+                [limit, ttlSeconds])
+            .WaitAsync(ctk);
+
+        var numeric = (long)redisResult;
+
+        if (numeric < 0)
+        {
+            var retryAfter = TimeSpan.FromSeconds(UtcCalendarDayRateLimit.GetSecondsUntilNextUtcDay(utcNow));
+            return new(false, limit, 0, retryAfter);
+        }
+
+        var remaining = (int)numeric;
+        return new(true, limit, remaining, null);
+    }
+
+    static string BuildKeyPrefix(IConfiguration configuration)
+    {
+        var instance = configuration[RedisInstanceNameKey];
+        if (string.IsNullOrWhiteSpace(instance))
+            return RateLimitKeyNamespace;
+
+        return $"{instance.TrimEnd(':')}:{RateLimitKeyNamespace}";
+    }
+
+    /// <summary>
+    /// Builds a Redis key scoped by operation, user, and UTC date so each calendar day uses a separate counter.
+    /// </summary>
+    RedisKey BuildRedisKey(UserRateLimitKind kind, Guid userId, DateTime utcNow)
+    {
+        var kindSegment = kind switch
+        {
+            UserRateLimitKind.CreateShortcut => "create",
+            UserRateLimitKind.RedirectShortcut => "redirect",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+        var day = utcNow.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture);
+        return $"{_keyPrefix}{kindSegment}:{userId:N}:{day}";
+    }
+}

--- a/src/Infrastructure/Services/RateLimiting/UtcCalendarDayRateLimit.cs
+++ b/src/Infrastructure/Services/RateLimiting/UtcCalendarDayRateLimit.cs
@@ -1,0 +1,25 @@
+namespace LinkyFunky.Infrastructure.Services.RateLimiting;
+
+/// <summary>
+/// Helpers for fixed UTC calendar-day rate limit windows and HTTP Retry-After values.
+/// </summary>
+public static class UtcCalendarDayRateLimit
+{
+    /// <summary>
+    /// Returns the time span from <paramref name="utcNow"/> until 00:00:00 of the next UTC day.
+    /// </summary>
+    public static TimeSpan GetTimeSpanUntilNextUtcDay(DateTime utcNow)
+    {
+        var startOfNext = utcNow.Date.AddDays(1);
+        return startOfNext - utcNow;
+    }
+
+    /// <summary>
+    /// Returns a positive number of whole seconds until the next UTC day, suitable for EXPIRE and Retry-After.
+    /// </summary>
+    public static int GetSecondsUntilNextUtcDay(DateTime utcNow)
+    {
+        var seconds = (int)Math.Ceiling(GetTimeSpanUntilNextUtcDay(utcNow).TotalSeconds);
+        return Math.Max(seconds, 1);
+    }
+}

--- a/src/Web/Defaults/AppHeaderNames.cs
+++ b/src/Web/Defaults/AppHeaderNames.cs
@@ -1,0 +1,8 @@
+namespace Web.Defaults;
+
+internal static class AppHeaderNames
+{ 
+    public const string RetryAfter = "Retry-After";
+    public const string RateLimitLimit = "RateLimit-Limit";
+    public const string RateLimitRemaining = "RateLimit-Remaining";
+}

--- a/src/Web/Endpoints/Shortcuts/GetRedirectByShortCodeEndpoint.cs
+++ b/src/Web/Endpoints/Shortcuts/GetRedirectByShortCodeEndpoint.cs
@@ -14,7 +14,7 @@ public sealed class GetRedirectByShortCodeEndpoint(IMediator sender)
 {
     public override void Configure()
     {
-        Get("/{shortCode}");
+        Get("/r/{shortCode}");
     }
 
     public override async Task HandleAsync(CancellationToken ctk)

--- a/src/Web/Middleware/UserDailyRateLimitMiddleware.cs
+++ b/src/Web/Middleware/UserDailyRateLimitMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using LinkyFunky.Application.Interfaces;
+using Web.Defaults;
 
 namespace Web.Middleware;
 
@@ -9,14 +10,6 @@ namespace Web.Middleware;
 /// <param name="next">The next middleware delegate.</param>
 public sealed class UserDailyRateLimitMiddleware(RequestDelegate next)
 {
-    static readonly HashSet<string> ReservedRedirectSegments =
-    [
-        "health",
-        "alive",
-        "scalar",
-        "openapi",
-    ];
-
     /// <summary>
     /// Invokes the middleware to enforce daily limits when the request maps to a rate-limited route.
     /// </summary>
@@ -35,29 +28,8 @@ public sealed class UserDailyRateLimitMiddleware(RequestDelegate next)
         }
 
         var result = await rateLimiter.TryAcquireAsync(userId, kind, httpContext.RequestAborted);
-        if (result.Allowed)
-        {
-            if (result.Limit > 0)
-            {
-                httpContext.Response.Headers.Append("RateLimit-Limit", result.Limit.ToString());
-                httpContext.Response.Headers.Append("RateLimit-Remaining", result.Remaining.ToString());
-            }
-
-            await next(httpContext);
-            return;
-        }
-
-        var retrySeconds = (int)Math.Ceiling((result.RetryAfter ?? TimeSpan.Zero).TotalSeconds);
-        httpContext.Response.Headers.Append("Retry-After", Math.Max(retrySeconds, 1).ToString());
-        if (result.Limit > 0)
-        {
-            httpContext.Response.Headers.Append("RateLimit-Limit", result.Limit.ToString());
-            httpContext.Response.Headers.Append("RateLimit-Remaining", "0");
-        }
-        httpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-        await httpContext.Response.WriteAsJsonAsync(
-            new { error = "Rate limit exceeded", window = "utc_day" },
-            httpContext.RequestAborted);
+        
+        await HandleRateLimitAsync(result, httpContext);
     }
 
     static bool TryGetUserId(ClaimsPrincipal user, out Guid userId)
@@ -84,6 +56,32 @@ public sealed class UserDailyRateLimitMiddleware(RequestDelegate next)
         return false;
     }
 
+    async Task HandleRateLimitAsync(RateLimitAcquireResult result, HttpContext httpContext)
+    {
+        httpContext.Response.Headers.Append(AppHeaderNames.RateLimitLimit, result.Limit.ToString());
+        var shouldWriteRemainingHeader = result.Limit > 0;
+
+        if (result.Allowed)
+        {
+            if (shouldWriteRemainingHeader)
+                httpContext.Response.Headers.Append(AppHeaderNames.RateLimitRemaining, result.Remaining.ToString());
+
+            await next(httpContext);
+            return;
+        }
+
+        var retrySeconds = (int)Math.Ceiling((result.RetryAfter ?? TimeSpan.Zero).TotalSeconds);
+        httpContext.Response.Headers.Append(AppHeaderNames.RetryAfter, Math.Max(retrySeconds, 1).ToString());
+
+        if (shouldWriteRemainingHeader)
+            httpContext.Response.Headers.Append(AppHeaderNames.RateLimitRemaining, "0");
+
+        httpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        await httpContext.Response.WriteAsJsonAsync(
+            new { error = "Rate limit exceeded", window = "utc_day" },
+            httpContext.RequestAborted);
+    }
+
     static bool IsCreateShortcutRequest(HttpRequest request) =>
         HttpMethods.IsPost(request.Method)
         && request.Path.Equals("/shortcuts", StringComparison.OrdinalIgnoreCase);
@@ -93,14 +91,7 @@ public sealed class UserDailyRateLimitMiddleware(RequestDelegate next)
         if (!HttpMethods.IsGet(request.Method))
             return false;
 
-        var path = request.Path;
-        if (!path.HasValue || path == "/")
-            return false;
-
-        var segments = path.Value.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
-        if (segments.Length != 1)
-            return false;
-
-        return !ReservedRedirectSegments.Contains(segments[0], StringComparer.OrdinalIgnoreCase);
+        var startsWithRedirectPrefix = request.Path.StartsWithSegments("/r", out var remainingPath);
+        return startsWithRedirectPrefix && remainingPath.HasValue && remainingPath.Value.StartsWith('/');
     }
 }

--- a/src/Web/Middleware/UserDailyRateLimitMiddleware.cs
+++ b/src/Web/Middleware/UserDailyRateLimitMiddleware.cs
@@ -1,0 +1,106 @@
+using System.Security.Claims;
+using LinkyFunky.Application.Interfaces;
+
+namespace Web.Middleware;
+
+/// <summary>
+/// Applies per-user daily Redis-backed quotas to shortcut creation and redirect endpoints.
+/// </summary>
+/// <param name="next">The next middleware delegate.</param>
+public sealed class UserDailyRateLimitMiddleware(RequestDelegate next)
+{
+    static readonly HashSet<string> ReservedRedirectSegments =
+    [
+        "health",
+        "alive",
+        "scalar",
+        "openapi",
+    ];
+
+    /// <summary>
+    /// Invokes the middleware to enforce daily limits when the request maps to a rate-limited route.
+    /// </summary>
+    public async Task InvokeAsync(HttpContext httpContext, IUserDailyRateLimitService rateLimiter)
+    {
+        if (!TryResolveRateLimitKind(httpContext.Request, out var kind))
+        {
+            await next(httpContext);
+            return;
+        }
+
+        if (!TryGetUserId(httpContext.User, out var userId))
+        {
+            await next(httpContext);
+            return;
+        }
+
+        var result = await rateLimiter.TryAcquireAsync(userId, kind, httpContext.RequestAborted);
+        if (result.Allowed)
+        {
+            if (result.Limit > 0)
+            {
+                httpContext.Response.Headers.Append("RateLimit-Limit", result.Limit.ToString());
+                httpContext.Response.Headers.Append("RateLimit-Remaining", result.Remaining.ToString());
+            }
+
+            await next(httpContext);
+            return;
+        }
+
+        var retrySeconds = (int)Math.Ceiling((result.RetryAfter ?? TimeSpan.Zero).TotalSeconds);
+        httpContext.Response.Headers.Append("Retry-After", Math.Max(retrySeconds, 1).ToString());
+        if (result.Limit > 0)
+        {
+            httpContext.Response.Headers.Append("RateLimit-Limit", result.Limit.ToString());
+            httpContext.Response.Headers.Append("RateLimit-Remaining", "0");
+        }
+        httpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        await httpContext.Response.WriteAsJsonAsync(
+            new { error = "Rate limit exceeded", window = "utc_day" },
+            httpContext.RequestAborted);
+    }
+
+    static bool TryGetUserId(ClaimsPrincipal user, out Guid userId)
+    {
+        var raw = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        return Guid.TryParse(raw, out userId);
+    }
+
+    static bool TryResolveRateLimitKind(HttpRequest request, out UserRateLimitKind kind)
+    {
+        kind = default;
+        if (IsCreateShortcutRequest(request))
+        {
+            kind = UserRateLimitKind.CreateShortcut;
+            return true;
+        }
+
+        if (IsRedirectShortcutRequest(request))
+        {
+            kind = UserRateLimitKind.RedirectShortcut;
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool IsCreateShortcutRequest(HttpRequest request) =>
+        HttpMethods.IsPost(request.Method)
+        && request.Path.Equals("/shortcuts", StringComparison.OrdinalIgnoreCase);
+
+    static bool IsRedirectShortcutRequest(HttpRequest request)
+    {
+        if (!HttpMethods.IsGet(request.Method))
+            return false;
+
+        var path = request.Path;
+        if (!path.HasValue || path == "/")
+            return false;
+
+        var segments = path.Value.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length != 1)
+            return false;
+
+        return !ReservedRedirectSegments.Contains(segments[0], StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -5,6 +5,7 @@ using Scalar.AspNetCore;
 using FastEndpoints;
 using Web;
 using Web.Authentication;
+using Web.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -29,6 +30,7 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseMiddleware<AnonymouslyAuthMiddleware>();
 app.UseAuthorization();
+app.UseMiddleware<UserDailyRateLimitMiddleware>();
 app.UseFastEndpoints();
 
 app.Run();

--- a/src/Web/appsettings.json
+++ b/src/Web/appsettings.json
@@ -1,4 +1,8 @@
 {
+  "RateLimits": {
+    "CreateShortcutPerUtcDay": 10,
+    "RedirectShortcutPerUtcDay": 50
+  },
   "Counters": {
     "SyncIntervalMinutes": 1
   },

--- a/tests/Infrastructure.UnitTests/Services/RateLimiting/UtcCalendarDayRateLimitTests.cs
+++ b/tests/Infrastructure.UnitTests/Services/RateLimiting/UtcCalendarDayRateLimitTests.cs
@@ -1,0 +1,29 @@
+using LinkyFunky.Infrastructure.Services.RateLimiting;
+
+namespace Infrastructure.UnitTests.Services.RateLimiting;
+
+/// <summary>
+/// Tests UTC calendar-day helpers used for Redis TTL and Retry-After headers.
+/// </summary>
+public sealed class UtcCalendarDayRateLimitTests
+{
+    [Fact]
+    public void GetSecondsUntilNextUtcDay_one_second_before_midnight_returns_one()
+    {
+        var utcNow = new DateTime(2026, 4, 30, 23, 59, 59, DateTimeKind.Utc);
+
+        var seconds = UtcCalendarDayRateLimit.GetSecondsUntilNextUtcDay(utcNow);
+
+        Assert.Equal(1, seconds);
+    }
+
+    [Fact]
+    public void GetTimeSpanUntilNextUtcDay_at_midnight_returns_full_day()
+    {
+        var utcNow = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var ts = UtcCalendarDayRateLimit.GetTimeSpanUntilNextUtcDay(utcNow);
+
+        Assert.Equal(TimeSpan.FromDays(1), ts);
+    }
+}


### PR DESCRIPTION
## Summary
This branch implements and stabilizes per-user daily rate limiting for link-related operations.  
It adds Redis-backed rate-limiting infrastructure, introduces middleware enforcement in the Web layer, and standardizes rate-limit response headers.  
It also updates the redirect route to use the `/r/` prefix and aligns redirect request detection logic in middleware.

## What Was Done
- Added a Redis-backed daily user rate-limit service with supporting contracts and configuration.
- Integrated `UserDailyRateLimitMiddleware` into the request pipeline to enforce limits by operation type.
- Introduced centralized rate-limit header constants in `AppHeaderNames`.
- Updated redirect endpoint route to `/r/{shortCode}`.
- Refactored middleware to:
  - simplify allowed/blocked response handling,
  - streamline `RateLimit-*` and `Retry-After` header writing,
  - correctly detect redirect requests by `/r/` path prefix.

## Released Behavior
- Rate-limited requests now return standardized headers:
  - `RateLimit-Limit`
  - `RateLimit-Remaining`
  - `Retry-After` (when the limit is exceeded)
- Requests exceeding limits return `429 Too Many Requests` with a JSON error payload.
- Short-link redirects are now served via the `/r/` route prefix.

## Notes
- Domain-level behavior remains backward compatible, but clients must use the new redirect path format (`/r/...`).