### PR TITLE
Unify HTTP response via ErrorResponse contract

### DIFF
--- a/src/Application/Common/Mappers/ErrorResponseMapping.cs
+++ b/src/Application/Common/Mappers/ErrorResponseMapping.cs
@@ -1,0 +1,25 @@
+using FluentResults;
+using LinkyFunky.Application.Contracts.Responses;
+
+namespace LinkyFunky.Application.Common.Mappers;
+
+public static class ErrorResponseMapping
+{
+    public static ErrorResponseList ToErrorResponse(this Result result)
+    {
+        return result.Errors.ToErrorResponse();
+    }
+    
+    public static ErrorResponseList ToErrorResponse<T>(this Result<T> result)
+    {
+        return result.Errors.ToErrorResponse();
+    }
+
+    static ErrorResponseList ToErrorResponse(this List<IError> errors)
+    {
+        var list = new ErrorResponseList();
+        list.AddRange(errors.Select(x => new ErrorResponse(x.Message)));
+
+        return list;
+    }
+}

--- a/src/Application/Contracts/Responses/ErrorResponse.cs
+++ b/src/Application/Contracts/Responses/ErrorResponse.cs
@@ -1,0 +1,5 @@
+namespace LinkyFunky.Application.Contracts.Responses;
+
+public sealed class ErrorResponseList : List<ErrorResponse>;
+
+public sealed record ErrorResponse(string Message);

--- a/src/Web/Authentication/AnonymouslyAuthMiddleware.cs
+++ b/src/Web/Authentication/AnonymouslyAuthMiddleware.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
+using Web.Extensions;
 
 namespace Web.Authentication;
 
@@ -32,7 +33,7 @@ public sealed class AnonymouslyAuthMiddleware(RequestDelegate next)
 
         if (signInResult.IsFailed)
         {
-            await httpContext.Response.WriteAsJsonAsync(signInResult);
+            await httpContext.Response.SendResultResponseAsync(signInResult);
             return;            
         }
 

--- a/src/Web/Endpoints/HealthCheck/GetHealthCheckEndpoint.cs
+++ b/src/Web/Endpoints/HealthCheck/GetHealthCheckEndpoint.cs
@@ -15,6 +15,6 @@ public class GetHealthCheckEndpoint : EndpointWithoutRequest
 
     public override Task HandleAsync(CancellationToken ctk)
     {
-        return HttpContext.Response.SendStringAsync("alive", StatusCodes.Status200OK, "text/plain", ctk);
+        return HttpContext.Response.SendStatusCodeAsync(StatusCodes.Status200OK, ctk);
     }
 }

--- a/src/Web/Endpoints/Shortcuts/GetRedirectByShortCodeEndpoint.cs
+++ b/src/Web/Endpoints/Shortcuts/GetRedirectByShortCodeEndpoint.cs
@@ -2,6 +2,7 @@ using FastEndpoints;
 using LinkyFunky.Application.Features.Shortcuts.GetShortcut;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using Web.Extensions;
 
 namespace Web.Endpoints.Shortcuts;
 
@@ -30,8 +31,8 @@ public sealed class GetRedirectByShortCodeEndpoint(IMediator sender)
         var result = await sender.Send(new GetShortcutLongUrlCommand(shortCode), ctk);
         if (result.IsFailed)
         {
-            HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
-            await HttpContext.Response.WriteAsJsonAsync(result.Errors.Select(x => x.Message), ctk);
+            await HttpContext.Response.SendResultResponseAsync(
+                result, errorCode: StatusCodes.Status404NotFound, ctk: ctk);
             return;
         }
 

--- a/src/Web/Endpoints/Shortcuts/PostCreateShortcutEndpoint.cs
+++ b/src/Web/Endpoints/Shortcuts/PostCreateShortcutEndpoint.cs
@@ -5,6 +5,7 @@ using LinkyFunky.Application.Contracts.Responses;
 using LinkyFunky.Application.Features.Shortcuts.CreateShortcut;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using Web.Extensions;
 
 namespace Web.Endpoints.Shortcuts;
 
@@ -23,20 +24,18 @@ public sealed class PostCreateShortcutEndpoint(IMediator sender) : Endpoint<Crea
     {
         if (!TryGetUserId(HttpContext.User, out var userId))
         {
-            HttpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await HttpContext.Response.SendStatusCodeAsync(StatusCodes.Status401Unauthorized, ctk);
             return;
         }
 
         var result = await sender.Send(new CreateShortcutCommand(userId, req.LongUrl), ctk);
         if (result.IsFailed)
         {
-            HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-            await HttpContext.Response.WriteAsJsonAsync(result.Errors.Select(x => x.Message), ctk);
+            await HttpContext.Response.SendResultResponseAsync(result, ctk: ctk);
             return;
         }
 
-        HttpContext.Response.StatusCode = StatusCodes.Status200OK;
-        await HttpContext.Response.WriteAsJsonAsync(result.Value, ctk);
+        await HttpContext.Response.SendResultResponseAsync(result, ctk: ctk);
     }
 
     static bool TryGetUserId(ClaimsPrincipal user, out Guid userId)

--- a/src/Web/Extensions/HttpResponseExtensions.cs
+++ b/src/Web/Extensions/HttpResponseExtensions.cs
@@ -1,0 +1,42 @@
+using FastEndpoints;
+using FluentResults;
+using LinkyFunky.Application.Common.Mappers;
+
+namespace Web.Extensions;
+
+internal static class HttpResponseExtensions
+{
+    public static Task SendResultResponseAsync<T>(
+        this HttpResponse response, 
+        Result<T> result,
+        int successCode = 200,
+        int errorCode = 400,
+        CancellationToken ctk = default)
+    {
+        if (result.IsSuccess)
+        {
+            response.StatusCode = successCode;
+            return response.WriteAsJsonAsync(result.Value, ctk);
+        }
+
+        response.StatusCode = errorCode;
+        return response.WriteAsJsonAsync(result.ToErrorResponse(), ctk);
+    }
+    
+    public static Task SendResultResponseAsync(
+        this HttpResponse response, 
+        Result result,
+        int successCode = 200,
+        int errorCode = 400,
+        CancellationToken ctk = default)
+    {
+        if (result.IsSuccess)
+        {
+            response.StatusCode = successCode;
+            return response.SendStatusCodeAsync(successCode, ctk);
+        }
+
+        response.StatusCode = errorCode;
+        return response.WriteAsJsonAsync(result.ToErrorResponse(), ctk);
+    }
+}

--- a/src/Web/Middleware/UserDailyRateLimitMiddleware.cs
+++ b/src/Web/Middleware/UserDailyRateLimitMiddleware.cs
@@ -1,6 +1,8 @@
 using System.Security.Claims;
+using FluentResults;
 using LinkyFunky.Application.Interfaces;
 using Web.Defaults;
+using Web.Extensions;
 
 namespace Web.Middleware;
 
@@ -76,10 +78,10 @@ public sealed class UserDailyRateLimitMiddleware(RequestDelegate next)
         if (shouldWriteRemainingHeader)
             httpContext.Response.Headers.Append(AppHeaderNames.RateLimitRemaining, "0");
 
-        httpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-        await httpContext.Response.WriteAsJsonAsync(
-            new { error = "Rate limit exceeded", window = "utc_day" },
-            httpContext.RequestAborted);
+        await httpContext.Response.SendResultResponseAsync(
+            Result.Fail("Rate limit exceeded"),
+            errorCode: StatusCodes.Status429TooManyRequests,
+            ctk: httpContext.RequestAborted);
     }
 
     static bool IsCreateShortcutRequest(HttpRequest request) =>


### PR DESCRIPTION
## Merge Request Description

### Summary
This MR unifies HTTP response formatting for failures by introducing a shared `ErrorResponse` contract and centralized response helpers.

### What Changed
- Added a common error response contract in `src/Application/Contracts/Responses/ErrorResponse.cs`:
  - `ErrorResponse` (record with `Message`)
  - `ErrorResponseList` (typed list wrapper)
- Added error mapping extensions in `src/Application/Common/Mappers/ErrorResponseMapping.cs` to convert `FluentResults` errors into `ErrorResponseList`.
- Added shared HTTP response helpers in `src/Web/Extensions/HttpResponseExtensions.cs`:
  - Unified success/error handling for `Result` and `Result<T>`
  - Configurable status codes for success and error branches
- Refactored endpoints/middleware to use shared response helpers instead of ad-hoc JSON/status handling:
  - `src/Web/Authentication/AnonymouslyAuthMiddleware.cs`
  - `src/Web/Endpoints/Shortcuts/GetRedirectByShortCodeEndpoint.cs`
  - `src/Web/Endpoints/Shortcuts/PostCreateShortcutEndpoint.cs`
  - `src/Web/Middleware/UserDailyRateLimitMiddleware.cs`
- Simplified healthcheck response in `src/Web/Endpoints/HealthCheck/GetHealthCheckEndpoint.cs` to status-only response.

### Why
- Ensures consistent API error payloads across web layer.
- Reduces duplicated response logic in endpoints and middleware.
- Makes result-to-HTTP mapping easier to maintain and extend.

### Test Plan
- Verify successful shortcut creation still returns `200` with expected payload.
- Verify shortcut lookup failure returns `404` with standardized `ErrorResponse` body.
- Verify invalid creation input returns `400` with standardized `ErrorResponse` body.
- Verify rate limit exceeded returns `429` with standardized `ErrorResponse` body.
- Verify anonymous auth failure returns standardized error response format.
- Verify healthcheck endpoint returns `200` status correctly.